### PR TITLE
Add Neo4j, Supabase stack, monitoring and AI models

### DIFF
--- a/DIFF_2025-08-15_22-20-34.md
+++ b/DIFF_2025-08-15_22-20-34.md
@@ -1,0 +1,7 @@
+## Changes on 2025-08-15 22:20:34 UTC
+- Added `docker-compose.yml` with Neo4j, Supabase, Prometheus, and Grafana services.
+- Added `install.sh` for one-click startup.
+- Created `app/models.py` defining Pydantic classes for model ensembles.
+- Created `docs/PROCEDURE.md` documenting setup and strategy.
+- Added `monitoring/prometheus.yml` for Prometheus configuration.
+- Updated `README.md` with quick start instructions and AI ensemble notes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# supa-container
+# Supa Container
+
+This repository provides a one-click script to run Neo4j, a self-hosted Supabase stack, and a monitoring suite (Prometheus + Grafana). It also includes Pydantic models for configuring ensembles of open source AI models.
+
+## Quick Start
+1. Ensure Docker is installed.
+2. Run `./install.sh`.
+3. See [docs/PROCEDURE.md](docs/PROCEDURE.md) for service URLs and details.
+
+## AI Ensemble
+`app/models.py` defines Pydantic classes to describe open source models and weighted ensembles. Adjust the configuration to combine multiple models.

--- a/RECOMMENDATIONS_2025-08-15_22-20-34.md
+++ b/RECOMMENDATIONS_2025-08-15_22-20-34.md
@@ -1,0 +1,6 @@
+## Recommendations on 2025-08-15 22:20:34 UTC
+- Add automated tests to validate container startup.
+- Configure Prometheus scrape targets for each service and add Grafana dashboards.
+- Secure Supabase credentials using environment variables or secret management.
+- Extend Pydantic models with runtime logic for ensemble predictions.
+- Document backup and restore procedures for databases.

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+class ModelSpec(BaseModel):
+    """Specification for a single open source model."""
+    name: str
+    path: str
+    description: Optional[str] = None
+    weight: float = Field(1.0, ge=0)
+
+class EnsembleConfig(BaseModel):
+    """Configuration for an ensemble of models."""
+    models: List[ModelSpec]
+    strategy: str = "weighted"
+
+    def weights(self) -> List[float]:
+        total = sum(m.weight for m in self.models)
+        if total == 0:
+            return [1 / len(self.models)] * len(self.models)
+        return [m.weight / total for m in self.models]
+
+class Prediction(BaseModel):
+    """Container for model predictions."""
+    model: str
+    output: str
+    score: Optional[float] = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+version: '3.9'
+services:
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    volumes:
+      - neo4j_data:/data
+    environment:
+      - NEO4J_AUTH=neo4j/test
+
+  supabase-db:
+    image: supabase/postgres:15.1.1.10
+    ports:
+      - "5432:5432"
+    volumes:
+      - supabase_db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+
+  supabase-rest:
+    image: supabase/postgrest:v10.2.6
+    depends_on:
+      - supabase-db
+    environment:
+      - PGRST_DB_URI=postgres://postgres:postgres@supabase-db:5432/postgres
+    ports:
+      - "3000:3000"
+
+  supabase-gotrue:
+    image: supabase/gotrue:v2.130.2
+    depends_on:
+      - supabase-db
+    environment:
+      - GOTRUE_DB_DRIVER=postgres
+      - DATABASE_URL=postgres://postgres:postgres@supabase-db:5432/postgres
+      - API_EXTERNAL_URL=http://localhost:9999
+    ports:
+      - "9999:9999"
+
+  supabase-realtime:
+    image: supabase/realtime:v2.19.3
+    depends_on:
+      - supabase-db
+    environment:
+      - DB_HOST=supabase-db
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
+      - DB_NAME=postgres
+    ports:
+      - "4000:4000"
+
+  supabase-storage:
+    image: supabase/storage-api:v0.40.8
+    depends_on:
+      - supabase-db
+    environment:
+      - ANON_KEY=anon-key
+      - SERVICE_KEY=service-role-key
+    ports:
+      - "5000:5000"
+
+  supabase-studio:
+    image: supabase/studio:20240421-2a5741b
+    depends_on:
+      - supabase-db
+    environment:
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "8080:3000"
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:10.4.5
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3001:3000"
+
+volumes:
+  neo4j_data:
+  supabase_db:
+  grafana_data:

--- a/docs/PROCEDURE.md
+++ b/docs/PROCEDURE.md
@@ -1,0 +1,29 @@
+# Procedure to Run the Stack
+
+This procedure outlines how to start the Neo4j database, the Supabase stack, and basic monitoring with Prometheus and Grafana. All components use open source images and can be orchestrated with a single command.
+
+## Prerequisites
+- [Docker](https://www.docker.com/get-started) and Docker Compose plugin
+- Sufficient resources: ~4GB RAM and 10GB disk space
+
+## Quick Start
+1. Clone this repository.
+2. Run `./install.sh`.
+3. Access services:
+   - Neo4j Browser: http://localhost:7474 (user: `neo4j`, pass: `test`)
+   - Supabase REST: http://localhost:3000
+   - Supabase Auth: http://localhost:9999
+   - Supabase Realtime: ws://localhost:4000/socket
+   - Supabase Storage: http://localhost:5000
+   - Supabase Studio: http://localhost:8080
+   - Prometheus: http://localhost:9090
+   - Grafana: http://localhost:3001
+
+## Ensemble AI Strategy
+Pydantic models in `app/models.py` describe an ensemble of open source models. Add model entries pointing to local paths or Hugging Face references and assign weights to control the ensemble strategy.
+
+## Transparency & Monitoring
+The monitoring stack provides transparency into system health. Extend `monitoring/prometheus.yml` with additional scrape targets for each service that exposes metrics.
+
+## Notes
+This setup is intended for local development. Review security settings before deploying to production.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting Neo4j, Supabase, and monitoring stack..."
+docker compose up -d
+
+echo "Services are starting. Check docker logs for progress."

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['prometheus:9090']


### PR DESCRIPTION
## Summary
- add docker-compose for Neo4j, Supabase, Prometheus and Grafana
- provide one-click install script
- include Pydantic models and procedure documentation

## Testing
- `pytest`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb2408878832abb3ab855dc23a7da

## Summary by Sourcery

Set up a one-click Docker-based environment for Neo4j, a self-hosted Supabase stack, and monitoring with Prometheus and Grafana, and introduce Pydantic models and documentation for configuring AI model ensembles.

New Features:
- Introduce docker-compose stack for Neo4j, Supabase services, Prometheus, and Grafana
- Add install.sh script for one-click startup of all services
- Add Pydantic models in app/models.py to define and configure AI model ensembles

Documentation:
- Add docs/PROCEDURE.md with detailed setup instructions and service URLs
- Update README.md with quick start guide and AI ensemble overview